### PR TITLE
Re-format code

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         {
             "name": "lpilp",
             "email": "lpilp@126.com",
-            "wx": "xiaopz129"
+            "homepage": "wechat://xiaopz129"
         }
     ],
     "require": {

--- a/src/smecc/SPLSM2/Sm2Asn1.php
+++ b/src/smecc/SPLSM2/Sm2Asn1.php
@@ -1,10 +1,13 @@
 <?php
 namespace Lpilp\Splsm2\smecc\SPLSM2;
+
 /**
  * 
  * 针对签名，加解密只有一层 asn1的解析，不做其他类型的解析，
  */
-define('MAXLEVEL', 2);  // 简单解析，只解析两层就够了
+
+const  MAXLEVEL = 2;  // 简单解析，只解析两层就够了
+
 class Sm2Asn1
 {
     const CLASS_UNIVERSAL        = 0;
@@ -50,7 +53,7 @@ class Sm2Asn1
     /**
      * 解析简单的asn1
      *
-     * @param string bin $data
+     * @param string $data bin
      * @param integer $level
      * @return array <string>
      */
@@ -125,8 +128,8 @@ class Sm2Asn1
     }
     /**
      * 
-     * @param string hex bigint $r
-     * @param string hex bigint $s
+     * @param string $r hex bigint
+     * @param string $s hex bigint
      * @return string base64  一般约定签名用bas64, 加解密用hex
      */
     public static function rs_2_asn1($r, $s, $outFormat = 'base64')
@@ -157,10 +160,10 @@ class Sm2Asn1
     /**
      * 
      *
-     * @param string hex bigint $c1x
-     * @param string hex bigint $c1y
-     * @param string hex bin $c3
-     * @param string hex bin $c2
+     * @param string $c1x hex bigint
+     * @param string $c1y hex bigint
+     * @param string $c3 hex bin
+     * @param string $c2 hex bin
      * @return string hex 一般约定签名用bas64, 加解密用hex
      */
     public static function asn1_cccc($c1x, $c1y, $c3, $c2, $outFormat = 'hex')

--- a/src/smecc/SPLSM2/Sm2Ecc.php
+++ b/src/smecc/SPLSM2/Sm2Ecc.php
@@ -1,8 +1,10 @@
 <?php
 namespace Lpilp\Splsm2\smecc\SPLSM2;
 
-class Sm2Ecc {
-    static function  get_params(){
+class Sm2Ecc
+{
+    static function get_params()
+    {
         return array(
             'p' => gmp_init("FFFFFFFEFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF00000000FFFFFFFFFFFFFFFF", 16),
             'a' => gmp_init("FFFFFFFEFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF00000000FFFFFFFFFFFFFFFC", 16),
@@ -10,9 +12,7 @@ class Sm2Ecc {
             'n' => gmp_init("FFFFFFFEFFFFFFFFFFFFFFFFFFFFFFFF7203DF6B21C6052B53BBF40939D54123", 16),
             'gx' => gmp_init("32C4AE2C1F1981195F9904466A39C9948FE30BBFF2660BE1715A4589334C74C7", 16),
             'gy' => gmp_init("BC3736A2F4F6779C59BDCEE36B692153D0A9877CC62A474002DF32E52139F0A0", 16),
-            'size'=>256
+            'size' => 256
         );
     }
-
 }
-

--- a/src/smecc/SPLSM2/Sm2Point.php
+++ b/src/smecc/SPLSM2/Sm2Point.php
@@ -1,6 +1,9 @@
 <?php
 namespace Lpilp\Splsm2\smecc\SPLSM2;
 
+use GMP;
+use RuntimeException;
+
 /**
  * from https://github.com/lat751608899/sm2/blob/main/src/Point.php
  * @author zlq <751608899@qq.com>
@@ -13,7 +16,7 @@ class Sm2Point
     protected $x;
     protected $y;
 
-    public function __construct(\GMP $x, \GMP $y)
+    public function __construct(GMP $x, GMP $y)
     {
         $this->x = $x;
         $this->y = $y;
@@ -22,12 +25,11 @@ class Sm2Point
 
     protected function init()
     {
-
         $eccParams = Sm2Ecc::get_params();
-        $this->eccParams=  $eccParams;
+        $this->eccParams = $eccParams;
     }
 
-    public function mul(\GMP $n, $isBase = true)
+    public function mul(GMP $n, $isBase = true)
     {
         $zero = gmp_init(0, 10);
         $n = gmp_mod($n, $this->eccParams['p']);
@@ -35,7 +37,7 @@ class Sm2Point
             return $this->getInfinity();
         }
         $p = $isBase ? new self($this->eccParams['gx'], $this->eccParams['gy']) : clone $this;
-        /** @var Point[] $r */
+        /** @var Sm2Point[] $r */
         $r = [
             $this->getInfinity(), // Q
             $p// P
@@ -44,7 +46,7 @@ class Sm2Point
         $n = strrev(str_pad($base, $this->eccParams['size'], '0', STR_PAD_LEFT));
         for ($i = 0; $i < $this->eccParams['size']; $i++) {
             $j = $n[$i];
-            if($j == 1){
+            if ($j == 1) {
                 $r[0] = $r[0]->add($r[1]); // r0 + r1 => p + 0 = p
             }
             $r[1] = $r[1]->getDouble();
@@ -79,7 +81,7 @@ class Sm2Point
             gmp_sub($addend->getX(), $this->x)  // x2 - x1
         );
         // λ² - x1 - x2
-        $xR =  $this->subMod(gmp_sub(gmp_pow($slope, 2), $this->x), $addend->getX());
+        $xR = $this->subMod(gmp_sub(gmp_pow($slope, 2), $this->x), $addend->getX());
         // (λ(x1 - x3)-y1)
         $yR = $this->subMod(gmp_mul($slope, gmp_sub($this->x, $xR)), $this->y);
 
@@ -110,11 +112,11 @@ class Sm2Point
 
     public function getInfinity()
     {
-        return new self(gmp_init(0,10), gmp_init(0,10));
+        return new self(gmp_init(0, 10), gmp_init(0, 10));
     }
 
     /**
-     * @return \GMP
+     * @return GMP
      */
     public function getX()
     {
@@ -122,7 +124,7 @@ class Sm2Point
     }
 
     /**
-     * @return \GMP
+     * @return GMP
      */
     public function getY()
     {
@@ -131,20 +133,20 @@ class Sm2Point
 
     public function isInfinity()
     {
-        return gmp_cmp($this->x, gmp_init(0,10)) === 0
-            && gmp_cmp($this->y, gmp_init(0,10)) === 0;
+        return gmp_cmp($this->x, gmp_init(0, 10)) === 0
+            && gmp_cmp($this->y, gmp_init(0, 10)) === 0;
     }
 
     /**
      * // k ≡ (x/y) (mod n) => ky ≡ x (mod n) => k y/x ≡ 1 (mod n)
-     * @param $x
-     * @param $y
-     * @param null $n
-     * @return \GMP|resource
+     * @param GMP $x
+     * @param GMP $y
+     * @param GMP $n
+     * @return GMP
      */
     protected function divMod($x, $y, $n = null)
     {
-        $n = $n?:$this->eccParams['p'];
+        $n = $n ?: $this->eccParams['p'];
         // y k ≡ 1 (mod n) => k ≡ 1/y (mod n)
         $k = gmp_invert($y, $n);
         // kx ≡ x/y (mod n)
@@ -155,10 +157,10 @@ class Sm2Point
 
     protected function subMod($x, $y, $n = null)
     {
-       return gmp_mod(gmp_sub($x, $y), $n?:$this->eccParams['p']);
+        return gmp_mod(gmp_sub($x, $y), $n ?: $this->eccParams['p']);
     }
 
-    public function contains(\GMP $x, \GMP $y)
+    public function contains(GMP $x, GMP $y)
     {
         $eq_zero = gmp_cmp(
             $this->subMod(
@@ -179,8 +181,8 @@ class Sm2Point
 
     public function checkOnLine()
     {
-        if($this->contains($this->x, $this->y) !== 0){
-            throw new \Exception('Invalid point');
+        if ($this->contains($this->x, $this->y) !== 0) {
+            throw new RuntimeException('Invalid point');
         }
 
         return true;

--- a/test/src/SmEccTest/TestSm4.php
+++ b/test/src/SmEccTest/TestSm4.php
@@ -4,6 +4,14 @@ namespace SmEccTest;
 use Lpilp\Splsm2\smecc\SPLSM2\Sm4;
 use SimpleTest\TestCase;
 
+class Sm4TestHelper extends Sm4
+{
+    public function increaseCounter($v)
+    {
+        return parent::increaseCounter($v);
+    }
+}
+
 class TestSm4 extends TestCase
 {
     public function testSm4()
@@ -31,5 +39,22 @@ class TestSm4 extends TestCase
             }
             self::assertSame($cipherText2, bin2hex($buf));
         }
+    }
+
+    public function testIncreaseCounter()
+    {
+        $sm4 = new Sm4TestHelper("\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00");
+
+        $out = $sm4->increaseCounter("\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00");
+        self::assertSame("\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01", $out);
+
+        $out = $sm4->increaseCounter("\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xff");
+        self::assertSame("\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01\x00", $out);
+
+        $out = $sm4->increaseCounter("\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff");
+        self::assertSame("\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00", $out);
+
+        $out = $sm4->increaseCounter("\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xff\xff\xff\xff\xff");
+        self::assertSame("\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00", $out);
     }
 }


### PR DESCRIPTION
Now we have tests, so we could safely refactor some codes.

Major changes:

1. composer reports `authors[0] : The property wx is not defined and the definition does not allow additional properties`, so use `homepage` field for it (officially documented)
2. use `const` instead of `define`
3. use `RuntimeException` instead of `Exception` (indeed, these "thorws" are for runtime)
4. fix various comments/phpdoc
5. re-format spaces/newlines
6. remove some deadcode, eg
    * `set_userid` related
    * `sm4->b` related (it is never assigned or used in code, and the padding should be prepared by caller)
7. add some new tests for sm4 (ctr)